### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jsonfeed
-[![PyPI](https://img.shields.io/pypi/v/jsonfeed-util)](https://pypi.org/project/jsonfeed-util/) [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/) [![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/lukasschwab/jsonfeed/python-package.yml?branch=master)](https://github.com/lukasschwab/jsonfeed/actions?query=branch%3Amaster) [![Full package documentation](https://img.shields.io/badge/docs-hosted-brightgreen)](https://lukasschwab.me/jsonfeed/index.html)
+[![PyPI](https://img.shields.io/pypi/v/jsonfeed-util)](https://pypi.org/project/jsonfeed-util/) [![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/lukasschwab/jsonfeed/python-package.yml?branch=master)](https://github.com/lukasschwab/jsonfeed/actions?query=branch%3Amaster) [![Full package documentation](https://img.shields.io/badge/docs-hosted-brightgreen)](https://lukasschwab.me/jsonfeed/index.html)
 
 `jsonfeed` is a Python package for parsing and constructing [JSON Feeds](https://jsonfeed.org/version/1.1). It explicitly supports JSON Feed Version 1.1.
 


### PR DESCRIPTION
There isn't pdoc compatibility. This could alternatively be solved by better-isolating requirements, but this isn't a widely used package so I can't be bothered.