### PR TITLE
Fix memory leak

### DIFF
--- a/jsonfeed/__init__.py
+++ b/jsonfeed/__init__.py
@@ -30,8 +30,8 @@ class Feed:
         authors: List["Author"] = None,
         expired: bool = False,
         language: str = None,
-        hubs: List["Hub"] = [],
-        items: List["Item"] = [],
+        hubs: List["Hub"] | None = None,
+        items: List["Item"] | None = None,
     ):
         assert title
         self.title = title
@@ -46,8 +46,8 @@ class Feed:
         self.authors = authors
         self.expired = expired
         self.language = language
-        self.hubs = hubs
-        self.items = items
+        self.hubs = hubs or []
+        self.items = items or []
 
     @staticmethod
     def parse(maybeFeed: dict) -> "Feed":
@@ -191,8 +191,8 @@ class Item:
         date_modified: str = None,
         author=None,  # 1.1 deprecated; use authors.
         authors: List[Author] = None,
-        tags: List[str] = [],
-        attachments: List["Attachment"] = [],
+        tags: List[str] | None = None,
+        attachments: List["Attachment"] | None = None,
     ):
         self.id = id
         self.url = url
@@ -207,8 +207,8 @@ class Item:
         self.date_modified = date_modified
         self.author = author
         self.authors = authors
-        self.tags = tags
-        self.attachments = attachments
+        self.tags = tags or None
+        self.attachments = attachments or None
 
     @staticmethod
     def parse(maybeItem: dict) -> "Item":

--- a/jsonfeed/__init__.py
+++ b/jsonfeed/__init__.py
@@ -207,8 +207,8 @@ class Item:
         self.date_modified = date_modified
         self.author = author
         self.authors = authors
-        self.tags = tags or None
-        self.attachments = attachments or None
+        self.tags = tags or []
+        self.attachments = attachments or []
 
     @staticmethod
     def parse(maybeItem: dict) -> "Item":

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,0 +1,21 @@
+import unittest
+
+from jsonfeed import Feed, Item, Hub
+
+
+class TestFeed(unittest.TestCase):
+    def test_items_memory_leak(self):
+        """Regression test for a bug found in the Feed class."""
+        feed = Feed("test")
+        feed.items.append(Item(id=1))
+
+        feed2 = Feed("test2")
+        self.assertEqual(feed2.items, [])
+
+    def test_hubs_memory_leak(self):
+        """Regression test for a bug found in the Feed class."""
+        feed = Feed("test")
+        feed.hubs.append(Hub("test", "https://example.com"))
+
+        feed2 = Feed("test2")
+        self.assertEqual(feed2.items, [])

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,0 +1,21 @@
+import unittest
+
+from jsonfeed import Item, Hub
+
+
+class TestFeed(unittest.TestCase):
+    def test_tags_memory_leak(self):
+        """Regression test for a bug found in the Item class."""
+        item = Item(id=1)
+        item.tags.append("test")
+
+        feed2 = Item("test2")
+        self.assertEqual(feed2.tags, [])
+
+    def test_attachments_memory_leak(self):
+        """Regression test for a bug found in the Item class."""
+        item = Item(id=1)
+        item.attachments.append("test")
+
+        feed2 = Item("test2")
+        self.assertEqual(feed2.attachments, [])


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description
If a list is used as a kwarg default, all calls to the function share the same instance of a list, causing data to be leaked between calls to the function.

## Breaking changes
None

# Relevant issues
I didn't raise an issue, but it was causing my application to create bigger and bigger feeds on each http request.

# Checklist

- [ ] (If appropriate) `README.md` example usage has been updated.
