### PR TITLE
Reintroduce Python 3.9 support

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -3,7 +3,7 @@ name: python-test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
   workflow_dispatch:
 
@@ -13,19 +13,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        make -B test
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          make -B test

--- a/jsonfeed/__init__.py
+++ b/jsonfeed/__init__.py
@@ -28,11 +28,11 @@ class Feed:
         icon: str = None,
         favicon: str = None,
         author=None,  # 1.1 deprecated; use authors.
-        authors: List["Author"] = None,
+        authors: list["Author"] = None,
         expired: bool = False,
         language: str = None,
-        hubs: List["Hub"] | None = None,
-        items: List["Item"] | None = None,
+        hubs: list["Hub"] | None = None,
+        items: list["Item"] | None = None,
     ):
         assert title
         self.title = title
@@ -191,9 +191,9 @@ class Item:
         date_published: str = None,
         date_modified: str = None,
         author=None,  # 1.1 deprecated; use authors.
-        authors: List[Author] = None,
-        tags: List[str] | None = None,
-        attachments: List["Attachment"] | None = None,
+        authors: list[Author] = None,
+        tags: list[str] | None = None,
+        attachments: list["Attachment"] | None = None,
     ):
         self.id = id
         self.url = url

--- a/jsonfeed/__init__.py
+++ b/jsonfeed/__init__.py
@@ -2,6 +2,8 @@
 
 import json
 
+from typing import Optional
+
 
 class ParseError(Exception):
     pass
@@ -19,19 +21,19 @@ class Feed:
     def __init__(
         self,
         title: str,
-        home_page_url: str = None,
-        feed_url: str = None,
-        description: str = None,
-        user_comment: str = None,
-        next_url: str = None,
-        icon: str = None,
-        favicon: str = None,
+        home_page_url: Optional[str] = None,
+        feed_url: Optional[str] = None,
+        description: Optional[str] = None,
+        user_comment: Optional[str] = None,
+        next_url: Optional[str] = None,
+        icon: Optional[str] = None,
+        favicon: Optional[str] = None,
         author=None,  # 1.1 deprecated; use authors.
-        authors: list["Author"] = None,
+        authors: Optional[list["Author"]] = None,
         expired: bool = False,
-        language: str = None,
-        hubs: list["Hub"] | None = None,
-        items: list["Item"] | None = None,
+        language: Optional[str] = None,
+        hubs: Optional[list["Hub"]] = None,
+        items: Optional[list["Item"]] = None,
     ):
         assert title
         self.title = title
@@ -120,7 +122,12 @@ class Feed:
 
 
 class Author:
-    def __init__(self, name: str = None, url: str = None, avatar: str = None):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        url: Optional[str] = None,
+        avatar: Optional[str] = None,
+    ):
         self.name = name
         self.url = url
         self.avatar = avatar
@@ -179,20 +186,20 @@ class Item:
     def __init__(
         self,
         id,
-        url: str = None,
-        external_url: str = None,
-        title: str = None,
-        content_html: str = None,
-        content_text: str = None,
-        summary: str = None,
-        image: str = None,
-        banner_image: str = None,
-        date_published: str = None,
-        date_modified: str = None,
+        url: Optional[str] = None,
+        external_url: Optional[str] = None,
+        title: Optional[str] = None,
+        content_html: Optional[str] = None,
+        content_text: Optional[str] = None,
+        summary: Optional[str] = None,
+        image: Optional[str] = None,
+        banner_image: Optional[str] = None,
+        date_published: Optional[str] = None,
+        date_modified: Optional[str] = None,
         author=None,  # 1.1 deprecated; use authors.
-        authors: list[Author] = None,
-        tags: list[str] | None = None,
-        attachments: list["Attachment"] | None = None,
+        authors: Optional[list[Author]] = None,
+        tags: Optional[list[str]] = None,
+        attachments: Optional[list["Attachment"]] = None,
     ):
         self.id = id
         self.url = url
@@ -278,9 +285,9 @@ class Attachment:
         self,
         url: str,
         mime_type: str,
-        title: str = None,
-        size_in_bytes: int = None,
-        duration_in_seconds: int = None,
+        title: Optional[str] = None,
+        size_in_bytes: Optional[int] = None,
+        duration_in_seconds: Optional[int] = None,
     ):
         self.url = url
         self.mime_type = mime_type

--- a/jsonfeed/__init__.py
+++ b/jsonfeed/__init__.py
@@ -1,7 +1,6 @@
 """.. include:: ../README.md"""
 
 import json
-from typing import List
 
 
 class ParseError(Exception):

--- a/jsonfeed/converters/feedparser.py
+++ b/jsonfeed/converters/feedparser.py
@@ -23,7 +23,6 @@ feed.to_json()
 ```
 """
 
-from typing import List
 from jsonfeed import Feed, Author, Item, Attachment
 from feedparser import FeedParserDict
 

--- a/jsonfeed/converters/feedparser.py
+++ b/jsonfeed/converters/feedparser.py
@@ -70,7 +70,7 @@ def from_feedparser_entry(entry: FeedParserDict) -> Item:
     )
 
 
-def from_feedparser_links(links: List[FeedParserDict]) -> List[Attachment]:
+def from_feedparser_links(links: list[FeedParserDict]) -> list[Attachment]:
     return [from_feedparser_link(link) for link in links]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-feedparser==6.0.2
+feedparser==6.0.11
 
 # Development dependencies
 pytest>=6.2.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 version = "1.1.4"
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     long_description = fh.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ setup(
     url="https://github.com/lukasschwab/jsonfeed",
     classifiers=[
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
# Description

+ Updates types.
  + `list` over `List`
  + `Optional` where appropriate; prefer over `T | None` unions. More expressive anyway.
+ Adds 3.9 to `python-version` matrix.
+ Adds supported Python versions to setup.py.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/jsonfeed/issues) relevant to this change.

+ Resolves #15 

# Checklist

- [-] (If appropriate) `README.md` example usage has been updated.
